### PR TITLE
Add Docker configuration for Keycloak with Nginx proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Use an official Keycloak image as a parent image
+FROM quay.io/keycloak/keycloak:latest
+
+# Set environment variables for Keycloak admin user
+# These can be overridden at runtime by docker-compose
+ENV KEYCLOAK_ADMIN=admin
+ENV KEYCLOAK_ADMIN_PASSWORD=admin
+
+# Expose the port Keycloak runs on
+EXPOSE 8080
+
+# Command to run Keycloak
+CMD ["start-dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  keycloak:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      KEYCLOAK_ADMIN: admin-user # Changed from Dockerfile default
+      KEYCLOAK_ADMIN_PASSWORD: strong-password # Changed from Dockerfile default
+      KC_PROXY: edge # Necessary when Keycloak is behind a reverse proxy
+    ports:
+      - "8080:8080" # Map host port 8080 to Keycloak's port 8080
+    networks:
+      - keycloak-net
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80" # Map host port 80 to Nginx's port 80
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro # Mount custom nginx configuration
+    depends_on:
+      - keycloak
+    networks:
+      - keycloak-net
+
+networks:
+  keycloak-net:
+    driver: bridge

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,23 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen 80;
+        server_name localhost; # Or your domain name
+
+        location / {
+            proxy_pass http://keycloak:8080; # Forward requests to the Keycloak service
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Server $host;
+
+            # Required for Keycloak admin console to work correctly behind a proxy
+            proxy_buffering off;
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces Dockerfile, docker-compose.yml, and nginx.conf to set up a Keycloak authentication server accessible via an Nginx reverse proxy.

- Dockerfile: Defines the Keycloak image using an official base image, sets default admin credentials (meant to be overridden), and exposes port 8080. Uses 'start-dev' for development purposes.

- docker-compose.yml:
  - Defines a 'keycloak' service built from the Dockerfile.
    - Overrides admin credentials.
    - Sets KC_PROXY=edge for proper operation behind a reverse proxy.
    - Maps host port 8080 to container port 8080.
  - Defines an 'nginx' service using the official Nginx image.
    - Maps host port 80 to container port 80.
    - Mounts a custom nginx.conf.
    - Depends on the keycloak service.
  - Both services are connected via a custom bridge network.

- nginx.conf:
  - Configures Nginx to listen on port 80.
  - Proxies requests to the Keycloak service at 'http://keycloak:8080'.
  - Sets necessary HTTP headers for reverse proxying (X-Forwarded-For, X-Forwarded-Proto, etc.).
  - Disables proxy_buffering for better compatibility with Keycloak's admin console.

Instructions on how to build and run these services, and considerations for production (database, HTTPS, credentials) have been provided.